### PR TITLE
Earthdaily python client v1.0.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# OS Related
 .DS_Store
 
+# Environment Variables
 .env
 .venv/
+
+# Ruby Related
+.Gemfile
+.Gemfile.lock
+_site/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@
 .venv/
 
 # Ruby Related
-.Gemfile
-.Gemfile.lock
+Gemfile
+Gemfile.lock
 _site/

--- a/API/Extensions/EDASTACextension.md
+++ b/API/Extensions/EDASTACextension.md
@@ -50,7 +50,6 @@ Below is the list of **public** fields available via API
  | eda:cloud_mask_collection_id | String      | EDA Cloud Mask collection id available for this item  |
  | eda:area_km2     | Number |   Mosaic - the approximate area in km^2 of the valid region of the mosaic                                           |
  | eda:radiometric_scaling| Number      |   Obsolete                                |
- | eda:orbit_number| String      |    The satellite orbit                               |
  | eda:pixel_composite_method| String      |    Pixel Composite Method used for Mosaics                               |
 
  Below are some of the **private** fields being available
@@ -71,8 +70,8 @@ Below is the list of **public** fields available via API
  | eda:source_created| String      | If we ingest third party item, we keep a track of when it was created in our system but we also maintain history of the actual item created. This is when third party created it
  | eda:source_updated| String      | If we ingest third party item, we keep a track of when it was updated in our system but we also maintain history of the actual item updated. This is when third party updated it             |
  | eda:unusable_cover     | Number | Estimate of unusable cover. Only for Land products. Unusable cover includes at least cloud and water.            |
- | eda:num_cols| String      |                                   |
- | eda:num_rows| String      |                                  |
+ | eda:num_cols| Number      | Number of columns in the image                                  |
+ | eda:num_rows| Number      | Number of rows in the image                                  |
  | eda:derived_from_l1c_item_id| String      | Which L1c item was used for the creation of the L1 derived products                                  |
  | eda:derived_from_l1c_collection_id     | String | Which L1c collection was used for the creation of the L1 derived collection                   |
  | eda:altitude| Number      |   Altitude of the image capture location. Altitude at the center of the product                                |
@@ -81,10 +80,11 @@ Below is the list of **public** fields available via API
  | eda:end_attitude| List of Numbers      |    Satellite attitude at the end of the acquisition (Degrees RPY )                               |
  | eda:mean_attitude| List of Numbers      |   Mean satellite attitude (Degrees RPY )                                |
  | eda:mtf_enhancement_applied| Boolean      |   Indicates whether MTF enhancement was applied                                |
- | eda:product_status| Number      |   Mosaic Product Status - Pending Validation, Valid, Deprecated . Obsolete                              |
+ | eda:bands| List of Strings      |   List of band names available in the product                                |
+ | eda:product_status| String      |   Product Status - One of "PENDING_VALIDATION", "VALID", "DEPRECATED"                              |
  | eda:source| String      |     Obsolete                              |
  | eda:auxiliary_atmospheric_sources| Object      |   Auxiliary atmospheric retrieval sources that were used for BOA generation (empty if none were used) Only applicable and included for L2A VNIR Basic Land BOA and L2A VNIR Advanced Land BOA products. e.g. `{ “aerosol”: “MODIS”, “water_vapour”: “ECMWF observation”}`
  | eda:basemap| String      |  The geometric reference used for any geometric corrections applied to the imagery  (Mosaic)                                |
- | eda:download_bundle_status| Number      |   Whether the download bundle asset is available or in progress. If this tag is absent, then the download bundle asset is not available for that item.|
+ | eda:download_bundle_status| String      |   Whether the download bundle asset is available or in progress. One of "AVAILABLE", "IN_PROGRESS". If this tag is absent, then the download bundle asset is not available for that item.|
  | eda:aocs_mode| String      |   AOCS Mode - One of “Nadir”, “DEM”, “Side Slither”.  Only provided for the Catalogue                                |
  | eda:cloud_detect_method| String | Algorithm used in cloud detection |

--- a/GettingStarted/QuickStart.md
+++ b/GettingStarted/QuickStart.md
@@ -86,27 +86,30 @@ You can find the detailed examples using [Python script](../API/APIUsage/Python.
 
 The fastest way to get up and running is to use EDA's [Python Client Repository](https://github.com/earthdaily/earthdaily-python-client). 
 
-Build a new Conda Environment:
+Build a new Virtual Environment:
 ```bash
-# Clone the repository and go inside
-git clone git@github.com:earthdaily/earthdaily-python-client.git
-cd earthdaily-python-client
+# Create a virtual environment
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-# Create a virtual environment named earthdaily and install package dependencies
-conda env create -n earthdaily -f requirements.yml
-conda activate earthdaily
-
-# Install package in editable mode
-pip install -e .
-
-copy-earthdaily-credentials-template --default
-
+# Install the EarthDaily Python client
+pip install earthdaily
 ```
+
+Create a `.env` file in your project directory with your API credentials:
+```
+EDS_AUTH_URL=https://api.earthdaily.com/account_management/v1/authentication/api_tokens/exchange
+EDS_CLIENT_ID=EARTHDAILY_API_TOKEN
+EDS_SECRET=<API_TOKEN>
+EDS_API_URL=https://api.earthdaily.com
+```
+
+**Important:** Replace `<API_TOKEN>` with your actual API secret from the [Account Management](https://console.earthdaily.com/account) page.
 
 
 Test the Available Collections:
 ```python
-from earthdaily.earthdatastore.cube_utils import asset_mapper
+from earthdaily.legacy.earthdatastore.cube_utils import asset_mapper
 from rich.table import Table
 from rich.console import Console
 


### PR DESCRIPTION
## Changes:
- Replaced how to install and use the `earthdaily-python-client` as we are moving to `v1`
- Changed `asset_mapper` to `legacy.asset_mapper`
- Updated the EDA Extension table with updated properties.

![image](https://github.com/user-attachments/assets/9ea6fe20-508a-4f9b-8c0a-66d809d4d326)
